### PR TITLE
Adding a 'just symlink to cgi-bin' nix-serve.cgi

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,20 +3,28 @@ with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "nix-serve-1";
 
-  buildInputs = [ perl nix perlPackages.Plack perlPackages.Starman ];
+  buildInputs = [ perl nix perlPackages.Plack perlPackages.Starman 
+    makeWrapper 
+  ];
 
   unpackPhase = "true";
 
   installPhase =
     ''
-      mkdir -p $out/libexec/nix-serve
-      cp ${./nix-serve.psgi} $out/libexec/nix-serve/nix-serve.psgi
+      mkdir -p "$out/libexec/nix-serve"
+      cp ${./nix-serve.psgi} "$out/libexec/nix-serve/nix-serve.psgi"
 
       mkdir -p $out/bin
-      cat > $out/bin/nix-serve <<EOF
-      #! ${stdenv.shell}
-      PERL5LIB=$PERL5LIB exec ${perlPackages.Starman}/bin/starman $out/libexec/nix-serve/nix-serve.psgi "\$@"
-      EOF
-      chmod +x $out/bin/nix-serve
+      makeWrapper '${perlPackages.Starman}/bin/starman' "$out/bin/nix-serve" \
+          --prefix PERL5LIB : "$PERL5LIB" \
+          --add-flags "$out/libexec/nix-serve/nix-serve.psgi"
+
+      makeWrapper '${perlPackages.Plack}/bin/plackup' "$out/bin/nix-serve.cgi" \
+          --prefix PERL5LIB : "$PERL5LIB" \
+          --prefix PATH : '${bzip2}/bin' \
+          --prefix PATH : '${nix}/bin' \
+          --set NIX_REMOTE daemon \
+          --set PATH_INFO '$QUERY_STRING' \
+          --add-flags "$out/libexec/nix-serve/nix-serve.psgi"
     '';
 }


### PR DESCRIPTION
Currently nix-serve as it is supposed to be run as a server. Add an option to use it as a CGI script with any HTTP server. The CGI can be just symlinked/copied to cgi-bin with zero configuration.
