### PR TITLE
When parsing sec key retain only the last ':' split section

### DIFF
--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -36,7 +36,7 @@ my $app = sub {
         if (defined $secretKeyFile) {
             my $s = readFile $secretKeyFile;
             chomp $s;
-            my ($keyName, $secretKey) = split ":", $s;
+            my ($keyName, $secretKey) = split /:([^:]+)$/, $s;
             die "invalid secret key file ‘$secretKeyFile’\n" unless defined $keyName && defined $secretKey;
             my $fingerprint = fingerprintPath($storePath, $narHash, $narSize, $refs);
             my $sig = encode_base64(signString(decode_base64($secretKey), $fingerprint), "");


### PR DESCRIPTION
Many times people use hostnames when declaring the key name. Sometimes those
hostnames contain port numbers in the form host:port. Previous parsing mechanism
would break in the presence of a colon in the hostname.