### PR TITLE
disable cpu-heavy compression

### DIFF
--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -14,19 +14,22 @@ my $app = sub {
     my $env = shift;
     my $path = $env->{PATH_INFO};
 
+    # log to journald
+    print "$env->{REQUEST_METHOD} $path\n";
+
     if ($path eq "/nix-cache-info") {
         return [200, ['Content-Type' => 'text/plain'], ["StoreDir: $Nix::Config::storeDir\nWantMassQuery: 1\nPriority: 30\n"]];
     }
 
-    elsif ($path =~ "/([0-9a-z]+)\.narinfo") {
+    elsif ($path =~ /^\/([0-9a-z]+)\.narinfo$/) {
         my $hashPart = $1;
         my $storePath = queryPathFromHashPart($hashPart);
         return [404, ['Content-Type' => 'text/plain'], ["No such path.\n"]] unless $storePath;
         my ($deriver, $narHash, $time, $narSize, $refs) = queryPathInfo($storePath, 1) or die;
         my $res =
             "StorePath: $storePath\n" .
-            "URL: nar/$hashPart.nar.bz2\n" .
-            "Compression: bzip2\n" .
+            "URL: nar/$hashPart.nar\n" .
+            "Compression: none\n" .
             "NarHash: $narHash\n" .
             "NarSize: $narSize\n";
         $res .= "References: " . join(" ", map { stripPath($_) } @$refs) . "\n"
@@ -45,12 +48,21 @@ my $app = sub {
         return [200, ['Content-Type' => 'text/x-nix-narinfo'], [$res]];
     }
 
-    elsif ($path =~ "/nar/([0-9a-z]+)\.nar.bz2") {
+    elsif ($path =~ /^\/nar\/([0-9a-z]+)\.nar\.bz2$/) {
         my $hashPart = $1;
         my $storePath = queryPathFromHashPart($hashPart);
         return [404, ['Content-Type' => 'text/plain'], ["No such path.\n"]] unless $storePath;
         my $fh = new IO::Handle;
-        open $fh, "nix-store --dump '$storePath' | bzip2 |";
+        open $fh, "nix-store --dump '$storePath' | bzip2 --fast |";
+        return [200, ['Content-Type' => 'text/plain'], $fh];
+    }
+
+    elsif ($path =~ /^\/nar\/([0-9a-z]+)\.nar$/) {
+        my $hashPart = $1;
+        my $storePath = queryPathFromHashPart($hashPart);
+        return [404, ['Content-Type' => 'text/plain'], ["No such path.\n"]] unless $storePath;
+        my $fh = new IO::Handle;
+        open $fh, "nix-store --dump '$storePath' |";
         return [200, ['Content-Type' => 'text/plain'], $fh];
     }
 


### PR DESCRIPTION
Disable bzip2.
It is too cpu-heavy even when there is a single client, with few clients it is nightmare.
```.nar.bz2``` files are still served to avoid dead links.