### PR TITLE
Fix repeat base 64 encode/decode.

### DIFF
--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -34,13 +34,11 @@ my $app = sub {
         $res .= "Deriver: " . stripPath($deriver) . "\n" if defined $deriver;
         my $secretKeyFile = $ENV{'NIX_SECRET_KEY_FILE'};
         if (defined $secretKeyFile) {
-            my $s = readFile $secretKeyFile;
-            chomp $s;
-            my ($keyName, $secretKey) = split ":", $s;
-            die "invalid secret key file ‘$secretKeyFile’\n" unless defined $keyName && defined $secretKey;
+            my $secretKey = readFile $secretKeyFile;
+            chomp $secretKey;
             my $fingerprint = fingerprintPath($storePath, $narHash, $narSize, $refs);
-            my $sig = encode_base64(signString(decode_base64($secretKey), $fingerprint), "");
-            $res .= "Sig: $keyName:$sig\n";
+            my $sig = signString($secretKey, $fingerprint);
+            $res .= "Sig: $sig\n";
         }
         return [200, ['Content-Type' => 'text/x-nix-narinfo'], [$res]];
     }


### PR DESCRIPTION
The Nix signString function now handles: secret key split; base 64 decode; and
base 64 encode of signature.

Without these changes the Key constructor in libstore/crypto will either
fail to split or fail on base64decode.

See: https://github.com/NixOS/nix/blob/4eb9e20028c4e52c23ce6a53fe02cac87171fda6/src/libstore/crypto.cc#L29

for where libstore base 64 decodes the parameter provided to signString.

Depending on client configuration this may result in a binary cache
failure that is largely masked from logging.