### PR TITLE
ca-derivations support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,64 @@
 {
   "nodes": {
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1617481909,
+        "narHash": "sha256-SqnfOFuLuVRRNeVJr1yeEPJue/qWoCp5N6o5Kr///p4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "148f9b2f586c41b7e36e73009db43ea68c7a1a4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "ref": "VERSION_0_8_4",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1627638914,
+        "narHash": "sha256-KnMQRMDqidemayib7HUTSbKuxFaLxHUEf9bGq+ajVzo=",
+        "owner": "nixos",
+        "repo": "nix",
+        "rev": "c15e121e322ee5bca1d96d59cc0b693e5bd9d0bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "ca/queryRealisation-perl",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1606086654,
-        "narHash": "sha256-VFl+3eGIMqNp7cyOMJ6TjM/+UcsLKtodKoYexrlTJMI=",
+        "lastModified": 1624862269,
+        "narHash": "sha256-JFcsh2+7QtfKdJFoPibLFPLgIW6Ycnv8Bts9a7RYme0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19db3e5ea2777daa874563b5986288151f502e27",
+        "rev": "f77036342e2b690c61c97202bf48f2ce13acc022",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.09",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nix": "nix",
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ]
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.09";
+  inputs.nixpkgs.follows = "nix/nixpkgs";
+  inputs.nix.url = "github:nixos/nix/ca/queryRealisation-perl";
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, nix }:
 
     let
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
@@ -13,7 +14,7 @@
         nix-serve = with final; stdenv.mkDerivation {
           name = "nix-serve-${self.lastModifiedDate}";
 
-          buildInputs = [ perl nix.perl-bindings perlPackages.Plack perlPackages.Starman perlPackages.DBDSQLite ];
+          buildInputs = [ perl nix.defaultPackage.${super.system}.passthru.perl-bindings perlPackages.Plack perlPackages.Starman perlPackages.DBDSQLite ];
 
           unpackPhase = "true";
 

--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -15,7 +15,7 @@ my $app = sub {
     my $path = $env->{PATH_INFO};
 
     if ($path eq "/nix-cache-info") {
-        return [200, ['Content-Type' => 'text/plain'], ["StoreDir: $Nix::Config::storeDir\nWantMassQuery: 1\nPriority: 30\n"]];
+        return [200, ['Content-Type' => 'text/plain'], ["StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 30\n"]];
     }
 
     elsif ($path =~ /^\/realisations\/(.*)\.doi/) {

--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -18,6 +18,13 @@ my $app = sub {
         return [200, ['Content-Type' => 'text/plain'], ["StoreDir: $Nix::Config::storeDir\nWantMassQuery: 1\nPriority: 30\n"]];
     }
 
+    elsif ($path =~ /^\/realisations\/(.*)\.doi/) {
+        my $rawDrvOutput = $1;
+        my $rawRealisation = queryRawRealisation($rawDrvOutput);
+        return [404, ['Content-Type' => 'text/plain'], ["No such derivation output.\n"]] unless $rawRealisation;
+        return [200, ['Content-Type' => 'text/plain'], [$rawRealisation]];
+    }
+
     elsif ($path =~ /^\/([0-9a-z]+)\.narinfo$/) {
         my $hashPart = $1;
         my $storePath = queryPathFromHashPart($hashPart);


### PR DESCRIPTION
Add a `/realisations` endpoint to support content-addressed derivations.

This required updating Nix (currently using a custom branch even) to access a new `queryRawRealisation` perl function that’s needed for that.

As part of this, I also had to upgrade nixpkgs to match the one used by the Nix flake, which caused an update of perl which in turn broke things:
- For some reason, the `/nix-cache-info` endpoint doesn’t properly interpolate the store dir anymore
- The `narinfo` files now have an extra newline at the end, which breaks the Nix parser

I’ll try to build everything with the old nixpkgs, seeing whether that fixes the issues for the time being

Fix #20 

/cc @Mic92 @zseri @SuperSandro2000