### PR TITLE
Support `nix log`

### DIFF
--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -72,6 +72,13 @@ my $app = sub {
         return [200, ['Content-Type' => 'text/plain', 'Content-Length' => $narSize], $fh];
     }
 
+    elsif ($path =~ /^\/log\/([0-9a-z]+-[0-9a-zA-Z\+\-\.\_\?\=]+)/) {
+        my $storePath = "$Nix::Config::storeDir/$1";
+        my $fh = new IO::Handle;
+        open $fh, "-|", "nix", "log", $storePath;
+        return [200, ['Content-Type' => 'text/plain' ], $fh];
+    }
+
     else {
         return [404, ['Content-Type' => 'text/plain'], ["File not found.\n"]];
     }


### PR DESCRIPTION
`nix log --store …` expects the remote cache to serve the log output
from a `/log/` endpoint, but currently only Hydra supports that endpoint.
The purpose of this change is to update `nix-serve` to also support the
same endpoint for parity with Hydra, so that `nix log` works when the
cache is hosted using `nix-serve`.