### PR TITLE
Don't generate extra newline when having zero signatures

### DIFF
--- a/nix-serve.psgi
+++ b/nix-serve.psgi
@@ -43,7 +43,7 @@ my $app = sub {
             my $sig = signString($secretKey, $fingerprint);
             $res .= "Sig: $sig\n";
         } elsif (defined $sigs) {
-            $res .= join("\n", map { "Sig: $_" } @$sigs) . "\n";
+            $res .= join("", map { "Sig: $_\n" } @$sigs);
         }
         return [200, ['Content-Type' => 'text/x-nix-narinfo', 'Content-Length' => length($res)], [$res]];
     }


### PR DESCRIPTION
When `$sigs` is defined but it is an array with zero elements, an extra newline is added to the response, making nix complain about corrupted narinfo file. With this change, no extra newline is added.