### PR TITLE
Load secret key on startup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
               #! ${stdenv.shell}
               PERL5LIB=$PERL5LIB \
               NIX_REMOTE="\''${NIX_REMOTE:-auto?path-info-cache-size=0}" \
-              exec ${perlPackages.Starman}/bin/starman $out/libexec/nix-serve/nix-serve.psgi "\$@"
+              exec ${perlPackages.Starman}/bin/starman --preload-app $out/libexec/nix-serve/nix-serve.psgi "\$@"
               EOF
               chmod +x $out/bin/nix-serve
             '';


### PR DESCRIPTION
Like others in #10 and #40, I was confused why signatures with `nix-serve` weren't working for me.

This fixes one possible source of confusion.

- Allow us to drop privileges (via starman command line flags) to a state where we are no longer able to read this file. This is useful if the secret key file is only readable by `root`, and we don't want to run a network-facing daemon as `root`. :slightly_smiling_face: 

- Crash with a clear error message on startup if a key is specified, but we are unable to read it (fixes #40).
