### PR TITLE
Support Nix::Store from 2.21 onwards

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1606086654,
-        "narHash": "sha256-VFl+3eGIMqNp7cyOMJ6TjM/+UcsLKtodKoYexrlTJMI=",
+        "lastModified": 1726447378,
+        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19db3e5ea2777daa874563b5986288151f502e27",
+        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.09",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.09";
+  inputs.nixpkgs.url = "nixpkgs/nixos-24.05";
 
   outputs = { self, nixpkgs }:
 
@@ -13,7 +13,7 @@
         nix-serve = with final; stdenv.mkDerivation {
           name = "nix-serve-${self.lastModifiedDate}";
 
-          buildInputs = [ perl nix.perl-bindings perlPackages.Plack perlPackages.Starman perlPackages.DBDSQLite ];
+          buildInputs = [ perl nixVersions.latest.perl-bindings perlPackages.Plack perlPackages.Starman perlPackages.DBDSQLite ];
 
           unpackPhase = "true";
 


### PR DESCRIPTION
- https://github.com/NixOS/nix/pull/9863
- https://github.com/NixOS/nix/commit/bc085022494fe90f733aef0832b6d7dcc34709cf

However, the library before and after this change exposes the same library version since it was [introduced] in Nix 1.0 which difficults writing compat code directly on nix-serve.

[introduced]: https://github.com/NixOS/nix/commit/73fe6871c479f7670f8c93b0cc9ef7bb1a851777